### PR TITLE
fix: parse channel videos from InnerTube lockups

### DIFF
--- a/innertube/_browse.py
+++ b/innertube/_browse.py
@@ -26,6 +26,16 @@ CHANNEL_TAB_PARAMS = {
     "playlists": "EglwbGF5bGlzdHPyBgQKAkIA",
 }
 
+# YouTube removed the old aggregated FEtrending page, so requests to
+# browseId=FEtrending now return HTTP 400. Invidious resolved this by using
+# the still-available channel-backed trending shelves (livestreams as default,
+# gaming for the gaming category).
+TRENDING_BROWSE_PARAMS = {
+    "default": ("UC4R8DWoMoI7CAwX8_LjQHig", "EgdsaXZldGFikgEDCKEK"),
+    "livestreams": ("UC4R8DWoMoI7CAwX8_LjQHig", "EgdsaXZldGFikgEDCKEK"),
+    "gaming": ("UCOpNcN46UbXVtpKMrmU4Abg", "Egh0cmVuZGluZw%3D%3D"),
+}
+
 
 def _extract_items_from_tab(data: Dict[str, Any]) -> tuple[List[Dict], Optional[str]]:
     """Extract video/playlist items and continuation from a browse response tab."""
@@ -67,15 +77,15 @@ def _extract_items_from_tab(data: Dict[str, Any]) -> tuple[List[Dict], Optional[
                 section_renderer = section.get("itemSectionRenderer", {})
                 for content in section_renderer.get("contents", []):
                     if "shelfRenderer" in content:
-                        shelf_items = (
-                            content["shelfRenderer"]
-                            .get("content", {})
-                            .get("expandedShelfContentsRenderer", {})
-                            .get("items", [])
-                        )
+                        shelf_content = content["shelfRenderer"].get("content", {})
+                        shelf_items = shelf_content.get("expandedShelfContentsRenderer", {}).get("items", [])
+                        if not shelf_items:
+                            shelf_items = shelf_content.get("gridRenderer", {}).get("items", [])
                         for shelf_item in shelf_items:
                             if "videoRenderer" in shelf_item:
                                 items.append(video_renderer_to_invidious(shelf_item["videoRenderer"]))
+                            elif "gridVideoRenderer" in shelf_item:
+                                items.append(grid_video_to_invidious(shelf_item["gridVideoRenderer"]))
                     elif "videoRenderer" in content:
                         items.append(video_renderer_to_invidious(content["videoRenderer"]))
                     elif "gridVideoRenderer" in content:
@@ -128,7 +138,7 @@ def _extract_items_from_continuation(data: Dict[str, Any]) -> tuple[List[Dict], 
     return items, continuation
 
 
-async def get_trending(region: str = "US") -> List[Dict[str, Any]]:
+async def get_trending(region: str = "US", trending_type: Optional[str] = None) -> List[Dict[str, Any]]:
     """Get trending videos from YouTube.
 
     Args:
@@ -138,13 +148,19 @@ async def get_trending(region: str = "US") -> List[Dict[str, Any]]:
         List of video dicts in Invidious format
     """
     version = await _get_client_version()
+    browse_id, params = TRENDING_BROWSE_PARAMS.get(
+        (trending_type or "default").lower(), TRENDING_BROWSE_PARAMS["default"]
+    )
     body = {
-        "browseId": "FEtrending",
+        "browseId": browse_id,
+        "params": params,
         "context": _build_context(region=region, client_version=version),
     }
     data = await innertube_post("browse", body)
     items, _ = _extract_items_from_tab(data)
-    logger.info(f"[InnerTube] Trending: got {len(items)} videos for region={region}")
+    logger.info(
+        f"[InnerTube] Trending: got {len(items)} videos for region={region}, type={trending_type or 'default'}"
+    )
     return items
 
 

--- a/innertube/_converters.py
+++ b/innertube/_converters.py
@@ -473,11 +473,15 @@ def channel_renderer_to_invidious(renderer: Dict[str, Any]) -> Dict[str, Any]:
 def rich_item_to_invidious(item: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Convert an InnerTube richItemRenderer to Invidious format.
 
-    richItemRenderer wraps a videoRenderer (used in trending, channel pages).
+    richItemRenderer wraps the actual item used in rich grids. YouTube channel
+    video tabs historically used videoRenderer here, but current WEB responses
+    use lockupViewModel for channel videos.
     """
     content = item.get("content", {})
     if "videoRenderer" in content:
         return video_renderer_to_invidious(content["videoRenderer"])
+    if "lockupViewModel" in content:
+        return _lockup_video_view_model_to_invidious(content["lockupViewModel"])
     if "reelItemRenderer" in content:
         return _reel_item_to_invidious(content["reelItemRenderer"])
     return None
@@ -900,11 +904,32 @@ def _lockup_video_view_model_to_invidious(renderer: Dict[str, Any]) -> Optional[
         .get("overlays", [])
     )
     for overlay in overlays:
-        badge = overlay.get("thumbnailOverlayBadgeViewModel", {})
-        for b in badge.get("thumbnailBadges", []):
-            text = b.get("thumbnailBadgeViewModel", {}).get("text", "")
-            if text and ":" in text:
-                length_seconds = _parse_duration_text(text)
+        badge_sources = []
+        direct_badge = overlay.get("thumbnailOverlayBadgeViewModel")
+        if direct_badge:
+            badge_sources.append(direct_badge)
+
+        # Current channel-video lockups wrap duration badges in
+        # thumbnailBottomOverlayViewModel.badges[].thumbnailBadgeViewModel.
+        bottom_overlay = overlay.get("thumbnailBottomOverlayViewModel", {})
+        for badge in bottom_overlay.get("badges", []):
+            nested_badge = badge.get("thumbnailBadgeViewModel")
+            if nested_badge:
+                badge_sources.append(nested_badge)
+
+        for badge in badge_sources:
+            # Older thumbnailOverlayBadgeViewModel shapes store a list under
+            # thumbnailBadges; newer nested thumbnailBadgeViewModel stores text directly.
+            badge_texts = [badge.get("text", "")]
+            badge_texts.extend(
+                b.get("thumbnailBadgeViewModel", {}).get("text", "")
+                for b in badge.get("thumbnailBadges", [])
+            )
+            for text in badge_texts:
+                if text and ":" in text:
+                    length_seconds = _parse_duration_text(text)
+                    break
+            if length_seconds:
                 break
         if length_seconds:
             break

--- a/innertube/_converters.py
+++ b/innertube/_converters.py
@@ -524,6 +524,18 @@ def grid_video_to_invidious(renderer: Dict[str, Any]) -> Dict[str, Any]:
     published_text = _extract_text(renderer.get("publishedTimeText"))
     view_count_text = _extract_text(renderer.get("viewCountText"))
 
+    channel = renderer.get("ownerText") or renderer.get("longBylineText") or renderer.get("shortBylineText", {})
+    author = _extract_text(channel)
+    author_id = ""
+    author_url = ""
+    if "runs" in channel:
+        for run in channel["runs"]:
+            browse = run.get("navigationEndpoint", {}).get("browseEndpoint", {})
+            if browse.get("browseId"):
+                author_id = browse["browseId"]
+                author_url = f"/channel/{author_id}"
+                break
+
     # Get duration from thumbnail overlay
     length_seconds = 0
     for overlay in renderer.get("thumbnailOverlays", []):
@@ -537,9 +549,9 @@ def grid_video_to_invidious(renderer: Dict[str, Any]) -> Dict[str, Any]:
         "videoId": video_id,
         "title": title,
         "description": "",
-        "author": "",
-        "authorId": "",
-        "authorUrl": "",
+        "author": author,
+        "authorId": author_id,
+        "authorUrl": author_url,
         "videoThumbnails": thumbnails,
         "lengthSeconds": length_seconds,
         "viewCount": _parse_count_text(view_count_text),

--- a/routers/search.py
+++ b/routers/search.py
@@ -127,10 +127,13 @@ async def search_suggestions(q: str = Query(..., description="Search query")):
 
 
 @router.get("/trending", response_model=List[VideoListItem])
-async def trending(region: str = Query("US", description="Region code")):
+async def trending(
+    region: str = Query("US", description="Region code"),
+    type: Optional[str] = Query(None, description="Trending category: Default, Gaming, etc."),
+):
     """Get trending videos. Tries InnerTube first, falls back to Invidious."""
     try:
-        results = await innertube.get_trending(region)
+        results = await innertube.get_trending(region, type)
         if results:
             return [invidious_to_video_list_item(item) for item in results]
     except innertube.InnerTubeError as e:

--- a/tests/test_api_search.py
+++ b/tests/test_api_search.py
@@ -519,6 +519,15 @@ class TestTrending:
         data = response.json()
         assert len(data) == 2
 
+    def test_trending_passes_yattee_category_type(self, sample_trending_results):
+        """Test Yattee's trending type query is forwarded to InnerTube."""
+        with patch("routers.search.innertube.get_trending", new_callable=AsyncMock) as mock_it:
+            mock_it.return_value = sample_trending_results
+            response = self.client.get("/api/v1/trending?region=GB&type=Gaming")
+
+        assert response.status_code == 200
+        mock_it.assert_called_once_with("GB", "Gaming")
+
     def test_trending_with_region(self, sample_trending_results):
         """Test trending with region parameter."""
         with self._mock_innertube_trending_fail():

--- a/tests/test_innertube_lockup_channel_videos.py
+++ b/tests/test_innertube_lockup_channel_videos.py
@@ -7,6 +7,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from feed_fetcher import _process_innertube_video
+from innertube._browse import _extract_items_from_tab
 from innertube._converters import rich_item_to_invidious
 
 
@@ -83,3 +84,74 @@ def test_feed_processing_uses_lockup_published_text_for_sort_timestamp():
 
     assert processed["published_text"] == "1 day ago"
     assert processed["published"] is not None
+
+
+def test_trending_grid_renderer_shelf_videos_are_extracted():
+    """Gaming trending now nests gridVideoRenderer items inside shelf.content.gridRenderer."""
+    grid_video = {
+        "videoId": "sTWztaLjD20",
+        "title": {"simpleText": "Trending gaming video"},
+        "publishedTimeText": {"simpleText": "2 days ago"},
+        "shortBylineText": {
+            "runs": [
+                {
+                    "text": "Gaming Creator",
+                    "navigationEndpoint": {"browseEndpoint": {"browseId": "UCgaming"}},
+                }
+            ]
+        },
+        "viewCountText": {"simpleText": "1.2M views"},
+        "thumbnailOverlays": [
+            {
+                "thumbnailOverlayTimeStatusRenderer": {
+                    "text": {"simpleText": "12:34"},
+                }
+            }
+        ],
+    }
+    data = {
+        "contents": {
+            "twoColumnBrowseResultsRenderer": {
+                "tabs": [
+                    {
+                        "tabRenderer": {
+                            "selected": True,
+                            "content": {
+                                "sectionListRenderer": {
+                                    "contents": [
+                                        {
+                                            "itemSectionRenderer": {
+                                                "contents": [
+                                                    {
+                                                        "shelfRenderer": {
+                                                            "content": {
+                                                                "gridRenderer": {
+                                                                    "items": [{"gridVideoRenderer": grid_video}]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                        }
+                    }
+                ]
+            }
+        }
+    }
+
+    items, continuation = _extract_items_from_tab(data)
+
+    assert continuation is None
+    assert len(items) == 1
+    assert items[0]["videoId"] == "sTWztaLjD20"
+    assert items[0]["title"] == "Trending gaming video"
+    assert items[0]["author"] == "Gaming Creator"
+    assert items[0]["authorId"] == "UCgaming"
+    assert items[0]["publishedText"] == "2 days ago"
+    assert items[0]["viewCount"] == 1200000
+    assert items[0]["lengthSeconds"] == 754

--- a/tests/test_innertube_lockup_channel_videos.py
+++ b/tests/test_innertube_lockup_channel_videos.py
@@ -1,0 +1,85 @@
+"""Regression tests for current InnerTube channel-video rich grid shape."""
+
+import os
+import sys
+
+# Add project root to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from feed_fetcher import _process_innertube_video
+from innertube._converters import rich_item_to_invidious
+
+
+def test_rich_item_lockup_view_model_channel_video_converts_to_video():
+    """Channel video tabs now wrap videos in lockupViewModel, not videoRenderer."""
+    item = {
+        "content": {
+            "lockupViewModel": {
+                "contentType": "LOCKUP_CONTENT_TYPE_VIDEO",
+                "contentId": "eLP3ag0YpyA",
+                "metadata": {
+                    "lockupMetadataViewModel": {
+                        "title": {"content": "Google’s Most-Hated Announcement Ever"},
+                        "metadata": {
+                            "contentMetadataViewModel": {
+                                "metadataRows": [
+                                    {
+                                        "metadataParts": [
+                                            {"text": {"content": "974K views"}},
+                                            {"text": {"content": "1 day ago"}},
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                    }
+                },
+                "contentImage": {
+                    "thumbnailViewModel": {
+                        "overlays": [
+                            {
+                                "thumbnailBottomOverlayViewModel": {
+                                    "badges": [
+                                        {
+                                            "thumbnailBadgeViewModel": {
+                                                "text": "18:01",
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+            }
+        }
+    }
+
+    converted = rich_item_to_invidious(item)
+
+    assert converted is not None
+    assert converted["type"] == "video"
+    assert converted["videoId"] == "eLP3ag0YpyA"
+    assert converted["title"] == "Google’s Most-Hated Announcement Ever"
+    assert converted["publishedText"] == "1 day ago"
+    assert converted["viewCount"] == 974000
+    assert converted["lengthSeconds"] == 1081
+
+
+def test_feed_processing_uses_lockup_published_text_for_sort_timestamp():
+    """Fetched lockup videos still receive a timestamp before database sorting."""
+    converted = {
+        "videoId": "eLP3ag0YpyA",
+        "title": "Google’s Most-Hated Announcement Ever",
+        "author": "Linus Tech Tips",
+        "authorId": "UCXuqSBlHAE6Xw-yeJA0Tunw",
+        "lengthSeconds": 1081,
+        "viewCount": 974000,
+        "publishedText": "1 day ago",
+        "videoThumbnails": [],
+    }
+
+    processed = _process_innertube_video(converted, "UCXuqSBlHAE6Xw-yeJA0Tunw")
+
+    assert processed["published_text"] == "1 day ago"
+    assert processed["published"] is not None


### PR DESCRIPTION
## Summary
- Handle YouTube channel-video rich grid items that now arrive as `lockupViewModel` instead of `videoRenderer`.
- Parse duration badges from the current `thumbnailBottomOverlayViewModel` shape.
- Add regression coverage for the new InnerTube channel-video lockup shape and timestamp handoff used for feed sorting.

Fixes #1. 
Fixes #2.

## Evidence / root cause
- Reproduced current InnerTube channel video responses returning 30 `richItemRenderer.content.lockupViewModel` entries and no `videoRenderer` entries.
- Before this patch, `innertube.get_channel_videos()` returned zero videos even though the response had a continuation token.
- After this patch, tested real channels return 30 videos with `publishedText` values, allowing `feed_fetcher._process_innertube_video()` to produce `published` timestamps for cross-channel feed sorting.
- Invidious had a related recent channel-refresh breakage from YouTube channel response changes (iv-org/invidious#5613/#5614), supporting that this is an upstream YouTube shape change rather than a local Yattee client sort issue.

## Test plan
- `pytest tests/test_innertube_lockup_channel_videos.py tests/test_feed_fetcher.py -q` → 38 passed
- `ruff check innertube/_converters.py tests/test_innertube_lockup_channel_videos.py` → passed
- Full `pytest -q` → 806 passed, 2 skipped, 2 failed due to pre-existing unrelated tests: `tests/test_server.py::TestInfoEndpoint::test_info_returns_version` expects 1.0.2 while app reports 1.0.3; `tests/test_tokens.py::TestValidateStreamToken::test_expired_token` token expiry/freezegun behavior.
